### PR TITLE
allow OpenMP to be enabled for bare metal toolchains

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -226,7 +226,7 @@ config CC_GCC_LIBMUDFLAP
 config CC_GCC_LIBGOMP
     bool
     prompt "Compile libgomp"
-    depends on !THREADS_NONE
+    #depends on !THREADS_NONE
     help
       libgomp is "the GNU implementation of the OpenMP Application Programming
       Interface (API) for multi-platform shared-memory parallel programming in

--- a/packages/gcc/11.2.0/1000-enable-bare-metal-OpenMP.patch
+++ b/packages/gcc/11.2.0/1000-enable-bare-metal-OpenMP.patch
@@ -1,0 +1,15 @@
+diff --git a/gcc/gcc.c b/gcc/gcc.c
+index 506c2acc282..e4ad71d18c7
+--- a/gcc/gcc.c
++++ b/gcc/gcc.c
+@@ -1335,9 +1335,7 @@ static const char *const multilib_defaults_raw[] = MULTILIB_DEFAULTS;
+ /* Linking to libgomp implies pthreads.  This is particularly important
+    for targets that use different start files and suchlike.  */
+ #ifndef GOMP_SELF_SPECS
+-#define GOMP_SELF_SPECS \
+-  "%{fopenacc|fopenmp|%:gt(%{ftree-parallelize-loops=*:%*} 1): " \
+-  "-pthread}"
++#define GOMP_SELF_SPECS ""
+ #endif
+ 
+ /* Likewise for -fgnu-tm.  */

--- a/setupOpenMP.txt
+++ b/setupOpenMP.txt
@@ -1,0 +1,21 @@
+This file describes modifications to an installed Cygwin-hosted toolchain which
+enable it to be ported to and used on a non-Cygwin Window PC.
+
+I install toolchains to c:/cross/arm-whatever-eabi.
+
+After building and installing GCC using ct-ng:
+
+Fix Windows security settings on the install directory so that changes can be made. 
+
+Copy cygwin1.dll and cyggcc_s-seh-1.dll to ./bin.
+
+Copy omp.h to ./lib/gcc/arm-multi-eabi/11.2.0/include (update path as needed).
+
+Delete empty ./include
+
+Create ./usr
+
+Move ./libexec to ./usr.
+
+Copy ./arm-multi-eabi to ./usr.
+


### PR DESCRIPTION
-- Comment out the line in config/cc/gcc.in which makes CC_GCC_LIBGOMP
depend on THREADS_NONE. This allows OpenMP to be enabled even if the
target does not have something like pthreads.

-- add a patch to gcc.c which removes the line at GOMP_SELF_SPECS which
makes the -fopenmp option dependent on -pthread.

With these two changes a .config can be created which enables -fopenmp
even for toolchains which do not support -pthread.